### PR TITLE
Add "X minutes to read"

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -241,9 +241,8 @@ format:
           </a>
           <script>
             (function () {
-              // Landing page is navigational, not a reading page
-              const offset = document.querySelector('meta[name="quarto:offset"]');
-              if (offset && offset.getAttribute("content") === "./") return;
+              // Index pages (site root and section landings) are navigational, not reading pages
+              if (/\/(index\.html)?$/.test(window.location.pathname)) return;
               const main = document.getElementById("quarto-document-content");
               if (!main) return;
               const words = (main.textContent.match(/\S+/g) || []).length;

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -221,6 +221,11 @@ format:
               background: #2aa198 !important;
               border-color: #2aa198 !important;
             }
+            .reading-time {
+              font-size: 0.9em;
+              color: var(--bs-secondary-color, #6c757d);
+              margin: 0 0 1rem;
+            }
           </style>
     include-after-body:
       - text: |
@@ -234,6 +239,26 @@ format:
           <a class="fab github-fab" href="https://github.com/emlab-ucsb/SOP" target="_blank" rel="noopener noreferrer" aria-label="Source Code" title="Source Code">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
           </a>
+          <script>
+            (function () {
+              // Landing page is navigational, not a reading page
+              const offset = document.querySelector('meta[name="quarto:offset"]');
+              if (offset && offset.getAttribute("content") === "./") return;
+              const main = document.getElementById("quarto-document-content");
+              if (!main) return;
+              const words = (main.textContent.match(/\S+/g) || []).length;
+              const minutes = Math.max(1, Math.round(words / 200));
+              const note = document.createElement("p");
+              note.className = "reading-time";
+              note.textContent = minutes + " min read";
+              const title = document.getElementById("title-block-header") || main.querySelector("h1");
+              if (title) {
+                title.insertAdjacentElement("afterend", note);
+              } else {
+                main.insertAdjacentElement("afterbegin", note);
+              }
+            })();
+          </script>
 
     grid:
       sidebar-width: 250px


### PR DESCRIPTION
Closes #62

Note that it skips */index.qmd pages. Those are generally just a summary paragraph and a references list and come in at 1 or 2 minutes (aside from Code). I think the tool is visual clutter on those short pages whereas it is useful info on longer subtopic pages.